### PR TITLE
Move unit tests back to their place

### DIFF
--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/pom.xml
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/pom.xml
@@ -126,6 +126,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>net.javacrumbs.json-unit</groupId>
+      <artifactId>json-unit-fluent</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>test</scope>
@@ -147,6 +152,51 @@
       <plugin>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-assertions-generator-maven-plugin</artifactId>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate-assertions</goal>
+            </goals>
+          </execution>
+        </executions>
+
+        <configuration>
+
+          <packages>
+            <package>org.activiti.cloud.services.core.model</package>
+            <package>org.activiti.cloud.services.audit.events</package>
+          </packages>
+          <classes>
+            <class>org.springframework.http.ResponseEntity</class>
+          </classes>
+
+          <!-- whether generated assertions classes can be inherited with consistent assertion chaining -->
+          <hierarchical>true</hierarchical>
+
+          <!-- where to generate assertions entry point classes -->
+          <entryPointClassPackage>${generated-assertions-package}</entryPointClassPackage>
+
+          <excludes>
+            <param>org\.activiti\.services\.core\.model\.converter.*</param>
+            <param>org\.activiti\.services\.core\.model\.commands.*</param>
+          </excludes>
+
+          <targetDir>${generated-assertions-folder}</targetDir>
+          <generateAssertions>true</generateAssertions>
+          <generateBddAssertions>false</generateBddAssertions>
+          <generateSoftAssertions>false</generateSoftAssertions>
+          <generateJUnitSoftAssertions>false</generateJUnitSoftAssertions>
+
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/EventsRelProviderTest.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/EventsRelProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-package org.activiti.cloud.starter.audit.tests.it;
+package org.activiti.cloud.services.audit;
 
-import org.activiti.cloud.services.audit.EventsRelProvider;
 import org.activiti.cloud.services.audit.events.ActivityCompletedEventEntity;
 import org.activiti.cloud.services.audit.events.ProcessEngineEventEntity;
-import org.activiti.cloud.services.api.events.ProcessEngineEvent;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class EventsRelProviderTest {
 
@@ -79,7 +77,7 @@ public class EventsRelProviderTest {
     @Test
     public void getItemResourceRelForShouldReturnLiteralEvent() throws Exception {
         //given
-        Class<ProcessEngineEvent> aClass = ProcessEngineEvent.class;
+        Class<ProcessEngineEventEntity> aClass = ProcessEngineEventEntity.class;
 
         //when
         String itemRel = relProvider.getItemResourceRelFor(aClass);

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/converter/ProcessInstanceJpaJsonConverterTest.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/converter/ProcessInstanceJpaJsonConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package org.activiti.cloud.starter.audit.tests.it.converter;
+package org.activiti.cloud.services.audit.converter;
 
 import java.util.Date;
 
-import org.activiti.cloud.services.audit.converter.ProcessInstanceJpaJsonConverter;
 import org.activiti.cloud.services.audit.events.model.ProcessInstance;
 import org.junit.Test;
 

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/converter/TaskJpaJsonConverterTest.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/converter/TaskJpaJsonConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package org.activiti.cloud.starter.audit.tests.it.converter;
+package org.activiti.cloud.services.audit.converter;
 
 import java.util.Date;
 
-import org.activiti.cloud.services.audit.converter.TaskJpaJsonConverter;
 import org.activiti.cloud.services.audit.events.model.Task;
 import org.junit.Test;
 

--- a/activiti-cloud-starter-audit/pom.xml
+++ b/activiti-cloud-starter-audit/pom.xml
@@ -246,20 +246,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>add-generated-assertions-folder</id>
-            <phase>generate-test-sources</phase>
-            <goals>
-              <goal>add-test-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>${generated-assertions-folder}</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.assertj</groupId>


### PR DESCRIPTION
Some unit tests where moved by mistake along to integration tests inside the starters. Just move them back to their right place.