### PR TITLE
Update copyright header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ hs_err_pid*
 .project
 .classpath
 .settings
+
+#MacOS
+.DS_Store

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/EventsRelProvider.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/EventsRelProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/channel/AuditConsumerChannelHandler.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/channel/AuditConsumerChannelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/channel/AuditConsumerChannels.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/channel/AuditConsumerChannels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/config/RepositoryConfig.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/config/RepositoryConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/converter/JpaJsonConverter.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/converter/JpaJsonConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/converter/ProcessInstanceJpaJsonConverter.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/converter/ProcessInstanceJpaJsonConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/converter/TaskJpaJsonConverter.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/converter/TaskJpaJsonConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/ActivityCancelledEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/ActivityCancelledEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/ActivityCompletedEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/ActivityCompletedEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/ActivityStartedEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/ActivityStartedEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/BaseActivityEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/BaseActivityEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/BaseProcessEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/BaseProcessEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/IntegrationEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/IntegrationEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/IntegrationRequestSentEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/IntegrationRequestSentEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/IntegrationResultReceivedEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/IntegrationResultReceivedEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/ProcessCancelledEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/ProcessCancelledEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/ProcessCompletedEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/ProcessCompletedEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/ProcessEngineEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/ProcessEngineEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/ProcessStartedEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/ProcessStartedEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/SequenceFlowTakenEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/SequenceFlowTakenEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/TaskAssignedEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/TaskAssignedEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/TaskCompletedEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/TaskCompletedEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/TaskCreatedEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/TaskCreatedEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/VariableCreatedEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/VariableCreatedEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/VariableDeletedEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/VariableDeletedEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/VariableUpdatedEventEntity.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/events/VariableUpdatedEventEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/repository/EventsRepository.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/repository/EventsRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/Application.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/channel/AuditConsumerChannelHandlerTest.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/channel/AuditConsumerChannelHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/repository/EventsRepositoryIT.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/repository/EventsRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/channel/AuditConsumerChannelHandler.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/channel/AuditConsumerChannelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/channel/AuditConsumerChannels.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/channel/AuditConsumerChannels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/ActivityCancelledEventDocument.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/ActivityCancelledEventDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/ActivityCompletedEventDocument.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/ActivityCompletedEventDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/ActivityStartedEventDocument.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/ActivityStartedEventDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/BaseActivityEventDocument.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/BaseActivityEventDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/BaseProcessEventDocument.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/BaseProcessEventDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/IntegrationEventDocument.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/IntegrationEventDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/IntegrationRequestSentEventDocument.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/IntegrationRequestSentEventDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/IntegrationResultReceivedEventDocument.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/IntegrationResultReceivedEventDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/ProcessCancelledEventDocument.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/ProcessCancelledEventDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/ProcessCompletedEventDocument.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/ProcessCompletedEventDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/ProcessStartedEventDocument.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/ProcessStartedEventDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/SequenceFlowTakenEventDocument.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/SequenceFlowTakenEventDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/TaskAssignedEventDocument.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/TaskAssignedEventDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/TaskCompletedEventDocument.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/TaskCompletedEventDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/TaskCreatedEventDocument.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/TaskCreatedEventDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/VariableCreatedEventDocument.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/VariableCreatedEventDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/VariableDeletedEventDocument.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/VariableDeletedEventDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/VariableUpdatedEventDocument.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/main/java/org/activiti/cloud/services/audit/mongo/events/VariableUpdatedEventDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/test/java/org/activiti/cloud/services/audit/mongo/channel/AuditConsumerChannelHandlerTest.java
+++ b/activiti-cloud-services-audit/activiti-cloud-services-audit-mongo/src/test/java/org/activiti/cloud/services/audit/mongo/channel/AuditConsumerChannelHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-services-audit/pom.xml
+++ b/activiti-cloud-services-audit/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2017 Alfresco, Inc. and/or its affiliates.
+  ~ Copyright 2018 Alfresco, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/activiti-cloud-starter-audit-mongo/src/main/java/org/activiti/cloud/starter/configuration/SwaggerConfig.java
+++ b/activiti-cloud-starter-audit-mongo/src/main/java/org/activiti/cloud/starter/configuration/SwaggerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-starter-audit-mongo/src/test/java/org/activiti/cloud/starter/audit/mongo/tests/it/AuditServiceIT.java
+++ b/activiti-cloud-starter-audit-mongo/src/test/java/org/activiti/cloud/starter/audit/mongo/tests/it/AuditServiceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-starter-audit-mongo/src/test/java/org/activiti/cloud/starter/audit/mongo/tests/it/EventsRestTemplate.java
+++ b/activiti-cloud-starter-audit-mongo/src/test/java/org/activiti/cloud/starter/audit/mongo/tests/it/EventsRestTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-starter-audit/src/main/java/org/activiti/cloud/starter/configuration/SwaggerConfig.java
+++ b/activiti-cloud-starter-audit/src/main/java/org/activiti/cloud/starter/configuration/SwaggerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/JpaAuditApplication.java
+++ b/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/JpaAuditApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
+++ b/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/EventsRestTemplate.java
+++ b/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/EventsRestTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- since a new year started the copyright year was updated to 2018
- ignore files generated by MacOS in repository

ref [#1686](https://github.com/Activiti/Activiti/issues/1686)