### PR TITLE
audit not working on postgres

### DIFF
--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/events/AuditEventEntity.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/events/AuditEventEntity.java
@@ -19,6 +19,7 @@ package org.activiti.cloud.services.audit.jpa.events;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
@@ -29,7 +30,7 @@ import javax.persistence.InheritanceType;
 public abstract class AuditEventEntity {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
     private Long id;
     protected String eventId;
     protected Long timestamp;


### PR DESCRIPTION
Seeing this issue in audit when on postgres:

https://stackoverflow.com/questions/29771730/postgres-error-in-batch-insert-relation-hibernate-sequence-does-not-exist-po/29772792

This is one option. Another option would be to just use what is currently 'eventId' as the Id and not generate a seperate id.

If we do that we might still want a logical ordering as events can have the same timestamp. For example if I create a standalone task with an assignee then the created and assigned events are simultaneous but the created event does come first. Adding a sequence number on the sender side might be preferable though as the generated ids on audit are strictly just recording order of receipt.