### PR TITLE
Handle process deployed event

### DIFF
--- a/activiti-cloud-services-audit-api/src/main/java/org/activiti/cloud/services/audit/api/converters/APIEventToEntityConverters.java
+++ b/activiti-cloud-services-audit-api/src/main/java/org/activiti/cloud/services/audit/api/converters/APIEventToEntityConverters.java
@@ -5,19 +5,10 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
-@Component
 public class APIEventToEntityConverters {
-
-    private static Logger LOGGER = LoggerFactory.getLogger(APIEventToEntityConverters.class);
 
     private Map<String, EventToEntityConverter> converters;
 
-    @Autowired
     public APIEventToEntityConverters(Set<EventToEntityConverter> convertersSet) {
         this.converters = convertersSet.stream().collect(Collectors.toMap(EventToEntityConverter::getSupportedEvent,
                                                                           Function.identity()));

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/conf/AuditJPAAutoConfiguration.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/conf/AuditJPAAutoConfiguration.java
@@ -16,6 +16,10 @@
 
 package org.activiti.cloud.services.audit.jpa.conf;
 
+import java.util.Set;
+
+import org.activiti.cloud.services.audit.api.converters.APIEventToEntityConverters;
+import org.activiti.cloud.services.audit.api.converters.EventToEntityConverter;
 import org.activiti.cloud.services.audit.jpa.converters.ActivityCancelledEventConverter;
 import org.activiti.cloud.services.audit.jpa.converters.ActivityCompletedEventConverter;
 import org.activiti.cloud.services.audit.jpa.converters.ActivityStartedEventConverter;
@@ -23,6 +27,7 @@ import org.activiti.cloud.services.audit.jpa.converters.EventContextInfoAppender
 import org.activiti.cloud.services.audit.jpa.converters.ProcessCancelledEventConverter;
 import org.activiti.cloud.services.audit.jpa.converters.ProcessCompletedEventConverter;
 import org.activiti.cloud.services.audit.jpa.converters.ProcessCreatedEventConverter;
+import org.activiti.cloud.services.audit.jpa.converters.ProcessDeployedEventConverter;
 import org.activiti.cloud.services.audit.jpa.converters.ProcessResumedEventConverter;
 import org.activiti.cloud.services.audit.jpa.converters.ProcessStartedEventConverter;
 import org.activiti.cloud.services.audit.jpa.converters.ProcessSuspendedEventConverter;
@@ -168,6 +173,18 @@ public class AuditJPAAutoConfiguration {
     @Bean
     public VariableUpdatedEventConverter variableUpdatedEventConverter(EventContextInfoAppender eventContextInfoAppender) {
         return new VariableUpdatedEventConverter(eventContextInfoAppender);
-    }      
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProcessDeployedEventConverter processDeployedEventConverter(EventContextInfoAppender eventContextInfoAppender) {
+        return new ProcessDeployedEventConverter(eventContextInfoAppender);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public APIEventToEntityConverters apiEventToEntityConverters(Set<EventToEntityConverter> eventToEntityConverters){
+        return new APIEventToEntityConverters(eventToEntityConverters);
+    }
     
 }

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ActivityCompletedEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ActivityCompletedEventConverter.java
@@ -7,9 +7,7 @@ import org.activiti.cloud.api.process.model.events.CloudBPMNActivityCompletedEve
 import org.activiti.cloud.api.process.model.impl.events.CloudBPMNActivityCompletedEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.ActivityCompletedAuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ActivityCompletedEventConverter extends BaseEventToEntityConverter {
 
     public ActivityCompletedEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ActivityStartedEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ActivityStartedEventConverter.java
@@ -7,9 +7,7 @@ import org.activiti.cloud.api.process.model.events.CloudBPMNActivityStartedEvent
 import org.activiti.cloud.api.process.model.impl.events.CloudBPMNActivityStartedEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.ActivityStartedAuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ActivityStartedEventConverter extends BaseEventToEntityConverter {
 
     public ActivityStartedEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ProcessCancelledEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ProcessCancelledEventConverter.java
@@ -7,9 +7,7 @@ import org.activiti.cloud.api.process.model.events.CloudProcessCancelledEvent;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCancelledEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.ProcessCancelledAuditEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ProcessCancelledEventConverter extends BaseEventToEntityConverter {
 
     public ProcessCancelledEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ProcessCompletedEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ProcessCompletedEventConverter.java
@@ -7,9 +7,7 @@ import org.activiti.cloud.api.process.model.events.CloudProcessCompletedEvent;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCompletedEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.ProcessCompletedEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ProcessCompletedEventConverter  extends BaseEventToEntityConverter {
     
     public ProcessCompletedEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ProcessCreatedEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ProcessCreatedEventConverter.java
@@ -7,9 +7,7 @@ import org.activiti.cloud.api.process.model.events.CloudProcessCreatedEvent;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCreatedEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.ProcessCreatedAuditEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ProcessCreatedEventConverter  extends BaseEventToEntityConverter {
 
     public ProcessCreatedEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ProcessDeployedEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ProcessDeployedEventConverter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.audit.jpa.converters;
+
+import org.activiti.api.process.model.events.ProcessDeployedEvent;
+import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
+import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
+import org.activiti.cloud.api.process.model.events.CloudProcessDeployedEvent;
+import org.activiti.cloud.api.process.model.impl.events.CloudProcessDeployedEventImpl;
+import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
+import org.activiti.cloud.services.audit.jpa.events.ProcessDeployedAuditEventEntity;
+
+public class ProcessDeployedEventConverter extends BaseEventToEntityConverter {
+
+    public ProcessDeployedEventConverter(EventContextInfoAppender eventContextInfoAppender) {
+        super(eventContextInfoAppender);
+    }
+
+    @Override
+    public String getSupportedEvent() {
+        return ProcessDeployedEvent.ProcessDefinitionEvents.PROCESS_DEPLOYED.name();
+    }
+
+    @Override
+    protected ProcessDeployedAuditEventEntity createEventEntity(CloudRuntimeEvent cloudRuntimeEvent) {
+        CloudProcessDeployedEvent cloudProcessDeployed = (CloudProcessDeployedEvent) cloudRuntimeEvent;
+        return new ProcessDeployedAuditEventEntity(cloudProcessDeployed.getId(),
+                                                   cloudProcessDeployed.getTimestamp(),
+                                                   cloudProcessDeployed.getAppName(),
+                                                   cloudProcessDeployed.getAppVersion(),
+                                                   cloudProcessDeployed.getServiceName(),
+                                                   cloudProcessDeployed.getServiceFullName(),
+                                                   cloudProcessDeployed.getServiceType(),
+                                                   cloudProcessDeployed.getServiceVersion(),
+                                                   cloudProcessDeployed.getEntity());
+    }
+
+    @Override
+    protected CloudRuntimeEventImpl<?, ?> createAPIEvent(AuditEventEntity auditEventEntity) {
+        ProcessDeployedAuditEventEntity processDeployedAuditEventEntity = (ProcessDeployedAuditEventEntity) auditEventEntity;
+        CloudProcessDeployedEventImpl processDeployedEvent = new CloudProcessDeployedEventImpl(processDeployedAuditEventEntity.getEventId(),
+                                                                                               processDeployedAuditEventEntity.getTimestamp(),
+                                                                                               processDeployedAuditEventEntity.getProcessDefinition());
+        processDeployedEvent.setAppName(processDeployedAuditEventEntity.getAppName());
+        processDeployedEvent.setAppVersion(processDeployedAuditEventEntity.getAppVersion());
+        processDeployedEvent.setServiceFullName(processDeployedAuditEventEntity.getServiceFullName());
+        processDeployedEvent.setServiceName(processDeployedAuditEventEntity.getServiceName());
+        processDeployedEvent.setServiceType(processDeployedAuditEventEntity.getServiceType());
+        processDeployedEvent.setServiceVersion(processDeployedAuditEventEntity.getServiceVersion());
+        return processDeployedEvent;
+    }
+}

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ProcessResumedEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ProcessResumedEventConverter.java
@@ -7,9 +7,7 @@ import org.activiti.cloud.api.process.model.events.CloudProcessResumedEvent;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessResumedEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.ProcessResumedAuditEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ProcessResumedEventConverter extends BaseEventToEntityConverter {
 
     public ProcessResumedEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ProcessStartedEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ProcessStartedEventConverter.java
@@ -7,9 +7,7 @@ import org.activiti.cloud.api.process.model.events.CloudProcessStartedEvent;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessStartedEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.ProcessStartedAuditEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ProcessStartedEventConverter extends BaseEventToEntityConverter {
    
     public ProcessStartedEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ProcessSuspendedEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ProcessSuspendedEventConverter.java
@@ -7,9 +7,7 @@ import org.activiti.cloud.api.process.model.events.CloudProcessSuspendedEvent;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessSuspendedEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.ProcessSuspendedAuditEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ProcessSuspendedEventConverter extends BaseEventToEntityConverter {
 
     public ProcessSuspendedEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ProcessUpdatedEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ProcessUpdatedEventConverter.java
@@ -7,9 +7,7 @@ import org.activiti.cloud.api.process.model.events.CloudProcessUpdatedEvent;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessUpdatedEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.ProcessUpdatedAuditEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ProcessUpdatedEventConverter extends BaseEventToEntityConverter {
     
     public ProcessUpdatedEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/SequenceFlowTakenEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/SequenceFlowTakenEventConverter.java
@@ -7,9 +7,7 @@ import org.activiti.cloud.api.process.model.events.CloudSequenceFlowTakenEvent;
 import org.activiti.cloud.api.process.model.impl.events.CloudSequenceFlowTakenImpl;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.SequenceFlowAuditEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class SequenceFlowTakenEventConverter extends BaseEventToEntityConverter {
     
     public SequenceFlowTakenEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/TaskAssignedEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/TaskAssignedEventConverter.java
@@ -7,9 +7,7 @@ import org.activiti.cloud.api.task.model.events.CloudTaskAssignedEvent;
 import org.activiti.cloud.api.task.model.impl.events.CloudTaskAssignedEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.TaskAssignedEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class TaskAssignedEventConverter extends BaseEventToEntityConverter {
 
     public TaskAssignedEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/TaskCancelledEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/TaskCancelledEventConverter.java
@@ -7,9 +7,7 @@ import org.activiti.cloud.api.task.model.events.CloudTaskCancelledEvent;
 import org.activiti.cloud.api.task.model.impl.events.CloudTaskCancelledEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.TaskCancelledEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class TaskCancelledEventConverter extends BaseEventToEntityConverter {
 
     public TaskCancelledEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/TaskCompletedEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/TaskCompletedEventConverter.java
@@ -7,9 +7,7 @@ import org.activiti.cloud.api.task.model.events.CloudTaskCompletedEvent;
 import org.activiti.cloud.api.task.model.impl.events.CloudTaskCompletedEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.TaskCompletedEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class TaskCompletedEventConverter extends BaseEventToEntityConverter {
     
     public TaskCompletedEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/TaskCreatedEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/TaskCreatedEventConverter.java
@@ -7,9 +7,7 @@ import org.activiti.cloud.api.task.model.events.CloudTaskCreatedEvent;
 import org.activiti.cloud.api.task.model.impl.events.CloudTaskCreatedEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.TaskCreatedEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class TaskCreatedEventConverter extends BaseEventToEntityConverter {
     
     public TaskCreatedEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/TaskSuspendedEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/TaskSuspendedEventConverter.java
@@ -7,9 +7,7 @@ import org.activiti.cloud.api.task.model.events.CloudTaskSuspendedEvent;
 import org.activiti.cloud.api.task.model.impl.events.CloudTaskSuspendedEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.TaskSuspendedEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class TaskSuspendedEventConverter extends BaseEventToEntityConverter {
 
     public TaskSuspendedEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/TaskUpdatedEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/TaskUpdatedEventConverter.java
@@ -23,9 +23,7 @@ import org.activiti.cloud.api.task.model.events.CloudTaskUpdatedEvent;
 import org.activiti.cloud.api.task.model.impl.events.CloudTaskUpdatedEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.TaskUpdatedEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class TaskUpdatedEventConverter extends BaseEventToEntityConverter {
 
     public TaskUpdatedEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/VariableCreatedEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/VariableCreatedEventConverter.java
@@ -7,9 +7,7 @@ import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
 import org.activiti.cloud.api.model.shared.impl.events.CloudVariableCreatedEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.VariableCreatedEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class VariableCreatedEventConverter extends BaseEventToEntityConverter {
 
     public VariableCreatedEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/VariableDeletedEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/VariableDeletedEventConverter.java
@@ -7,9 +7,7 @@ import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
 import org.activiti.cloud.api.model.shared.impl.events.CloudVariableDeletedEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.VariableDeletedEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class VariableDeletedEventConverter extends BaseEventToEntityConverter {
 
     public VariableDeletedEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/VariableUpdatedEventConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/VariableUpdatedEventConverter.java
@@ -7,9 +7,7 @@ import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
 import org.activiti.cloud.api.model.shared.impl.events.CloudVariableUpdatedEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.VariableUpdatedEventEntity;
-import org.springframework.stereotype.Component;
 
-@Component
 public class VariableUpdatedEventConverter extends BaseEventToEntityConverter {
 
     public VariableUpdatedEventConverter(EventContextInfoAppender eventContextInfoAppender) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/json/JpaJsonConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/json/JpaJsonConverter.java
@@ -31,9 +31,11 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.process.model.BPMNActivity;
 import org.activiti.api.process.model.BPMNSequenceFlow;
+import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.runtime.model.impl.BPMNActivityImpl;
 import org.activiti.api.runtime.model.impl.BPMNSequenceFlowImpl;
+import org.activiti.api.runtime.model.impl.ProcessDefinitionImpl;
 import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
 import org.activiti.api.runtime.model.impl.VariableInstanceImpl;
 import org.activiti.api.task.model.Task;
@@ -58,6 +60,9 @@ public class JpaJsonConverter<T> implements AttributeConverter<T, String> {
                                            typeDesc.getType());
                 }
             };
+
+            resolver.addMapping(ProcessDefinition.class,
+                                ProcessDefinitionImpl.class);
 
             resolver.addMapping(VariableInstance.class,
                                 VariableInstanceImpl.class);

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/json/ProcessDefinitionJpaJsonConverter.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/json/ProcessDefinitionJpaJsonConverter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.audit.jpa.converters.json;
+
+import org.activiti.api.process.model.ProcessDefinition;
+
+public class ProcessDefinitionJpaJsonConverter extends JpaJsonConverter<ProcessDefinition> {
+
+    public ProcessDefinitionJpaJsonConverter() {
+        super(ProcessDefinition.class);
+    }
+}

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/events/ProcessDeployedAuditEventEntity.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/events/ProcessDeployedAuditEventEntity.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.audit.jpa.events;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Lob;
+
+import org.activiti.api.process.model.ProcessDefinition;
+import org.activiti.api.process.model.events.ProcessDefinitionEvent;
+import org.activiti.cloud.services.audit.jpa.converters.json.ProcessDefinitionJpaJsonConverter;
+
+@Entity
+@DiscriminatorValue(value = ProcessDeployedAuditEventEntity.PROCESS_DEPLOYED_EVENT)
+public class ProcessDeployedAuditEventEntity extends AuditEventEntity {
+
+    protected static final String PROCESS_DEPLOYED_EVENT = "ProcessDeployedEvent";
+
+    @Convert(converter = ProcessDefinitionJpaJsonConverter.class)
+    @Lob
+    @Column
+    private ProcessDefinition processDefinition;
+
+    public ProcessDeployedAuditEventEntity() {
+    }
+
+    public ProcessDeployedAuditEventEntity(String eventId,
+                                           Long timestamp) {
+        super(eventId,
+              timestamp,
+              ProcessDefinitionEvent.ProcessDefinitionEvents.PROCESS_DEPLOYED.name());
+    }
+    public ProcessDeployedAuditEventEntity(String eventId,
+                                           Long timestamp,
+                                           String appName,
+                                           String appVersion,
+                                           String serviceName,
+                                           String serviceFullName,
+                                           String serviceType,
+                                           String serviceVersion,
+                                           ProcessDefinition processDefinition) {
+        this(eventId,
+              timestamp);
+        setAppName(appName);
+        setAppName(appName);
+        setAppVersion(appVersion);
+        setServiceName(serviceName);
+        setServiceFullName(serviceFullName);
+        setServiceType(serviceType);
+        setServiceVersion(serviceVersion);
+        setProcessDefinition(processDefinition);
+    }
+
+
+
+    public ProcessDefinition getProcessDefinition() {
+        return processDefinition;
+    }
+
+    public void setProcessDefinition(ProcessDefinition processDefinition) {
+        this.processDefinition = processDefinition;
+    }
+}

--- a/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
+++ b/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 
 import org.activiti.api.process.model.events.BPMNActivityEvent;
 import org.activiti.api.runtime.model.impl.BPMNActivityImpl;
+import org.activiti.api.runtime.model.impl.ProcessDefinitionImpl;
 import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
 import org.activiti.api.task.model.Task;
 import org.activiti.api.task.model.events.TaskRuntimeEvent;
@@ -44,6 +45,7 @@ import org.activiti.cloud.api.process.model.impl.events.CloudBPMNActivityComplet
 import org.activiti.cloud.api.process.model.impl.events.CloudBPMNActivityStartedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCancelledEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCompletedEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudProcessDeployedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessStartedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessSuspendedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessUpdatedEventImpl;
@@ -417,7 +419,6 @@ public class AuditServiceIT {
         });
     }
 
-    
     @Test
     public void checkEventConverters() {
         //given
@@ -508,6 +509,8 @@ public class AuditServiceIT {
 
     private List<CloudRuntimeEvent> getTestEvents() {
         List<CloudRuntimeEvent> testEvents = new ArrayList<>();
+
+        testEvents.add(new CloudProcessDeployedEventImpl(buildDefaultProcessDefinition()));
 
         BPMNActivityImpl bpmnActivityCancelled = new BPMNActivityImpl();
         bpmnActivityCancelled.setElementId("elementId");
@@ -644,6 +647,14 @@ public class AuditServiceIT {
         testEvents.add(cloudTaskCancelledEvent);
 
         return testEvents;
+    }
+
+    private ProcessDefinitionImpl buildDefaultProcessDefinition() {
+        ProcessDefinitionImpl processDefinition = new ProcessDefinitionImpl();
+        processDefinition.setName("My process");
+        processDefinition.setKey("my proc");
+        processDefinition.setId("processId");
+        return processDefinition;
     }
 
     private List<CloudRuntimeEvent> getTestProcessStartedUpdatedCompletedEvents() {


### PR DESCRIPTION
Currently audit is not handling duplicates: process deployed events are triggered when the runtime bundle application is up and running, so the same event will be sent more than once if the runtime bundle get restarted. Audit is storing every occurrence of such events.

Refs https://github.com/Activiti/Activiti/issues/2231