### PR TITLE
AAE-771 Tests extended to check taskDefinitionKey

### DIFF
--- a/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/TaskCreatedEventConverterTest.java
+++ b/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/TaskCreatedEventConverterTest.java
@@ -67,6 +67,7 @@ public class TaskCreatedEventConverterTest {
         TaskImpl taskCreated = new TaskImpl("1234-abc-5678-def",
                                             "my task",
                                             Task.TaskStatus.CREATED);
+        taskCreated.setTaskDefinitionKey("taskDefinitionKey");
         CloudTaskCreatedEventImpl cloudTaskCreatedEvent = new CloudTaskCreatedEventImpl("TaskCreatedEventId",
                                                                                         System.currentTimeMillis(),
                                                                                         taskCreated);

--- a/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
+++ b/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
@@ -94,11 +94,6 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-import static org.awaitility.Awaitility.await;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext

--- a/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
+++ b/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
@@ -193,7 +193,7 @@ public class AuditServiceIT {
     }
     
     @Test
-    public void shouldBeAbleToFilterOnProcessInstanceIdTaskCreatedEvent() {
+    public void should_getTaskCreatedEvent_when_filteredOnProcessInstanceIdEventType() {
         //given
         List<CloudRuntimeEvent> coveredEvents = getTestEvents();
         producer.send(coveredEvents.toArray(new CloudRuntimeEvent[coveredEvents.size()]));
@@ -226,9 +226,7 @@ public class AuditServiceIT {
 
         });
     }
-    
-    
-
+   
     @Test
     public void shouldGetProcessStartedUpdatedCompletedEvents() {
         //given

--- a/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
+++ b/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
@@ -210,11 +210,8 @@ public class AuditServiceIT {
             ResponseEntity<PagedResources<CloudRuntimeEvent>> eventsPagedResources = eventsRestTemplate.executeFind(filters);
 
             //then
-            Collection<CloudRuntimeEvent> retrievedEvents = eventsRestTemplate
-                                                            .executeFind(filters)
-                                                            .getBody()
-                                                            .getContent();
-            assertThat(retrievedEvents)
+            assertThat(eventsPagedResources).isNotNull();
+            assertThat(eventsPagedResources.getBody())
                 .isNotEmpty()
                 .filteredOn(event -> ((CloudTaskCreatedEvent)event).getEntity().getTaskDefinitionKey().equals("taskDefinitionKey"))
                 .extracting(event -> event.getEventType(),


### PR DESCRIPTION
Related to https://github.com/Activiti/Activiti/issues/2766
Depends on:
https://github.com/Activiti/activiti-api/pull/126
https://github.com/Activiti/activiti-cloud-api/pull/96
https://github.com/Activiti/Activiti/pull/2797
https://github.com/Activiti/activiti-cloud-runtime-bundle-service/pull/320
https://github.com/Activiti/activiti-cloud-query-service/pull/245
