### PR TITLE
[ACTIVITI-3867] rename sequence with custom name

### DIFF
--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/events/AuditEventEntity.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/events/AuditEventEntity.java
@@ -33,7 +33,7 @@ import javax.persistence.InheritanceType;
 public abstract class AuditEventEntity {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(generator = "audit_sequence")
     private Long id;
     private String eventId;
     private Long timestamp;
@@ -56,7 +56,7 @@ public abstract class AuditEventEntity {
     private String processDefinitionKey;
     private String parentProcessInstanceId;
     private String businessKey;
-    
+
     public AuditEventEntity() {
     }
 
@@ -183,7 +183,7 @@ public abstract class AuditEventEntity {
     public void setEntityId(String entityId) {
         this.entityId = entityId;
     }
-    
+
     public String getBusinessKey() {
         return businessKey;
     }
@@ -258,23 +258,23 @@ public abstract class AuditEventEntity {
             return false;
         }
         AuditEventEntity other = (AuditEventEntity) obj;
-        return Objects.equals(appName, other.appName) 
-                && Objects.equals(appVersion, other.appVersion) 
-                && Objects.equals(businessKey, other.businessKey) 
-                && Objects.equals(entityId, other.entityId) 
-                && Objects.equals(eventId, other.eventId) 
-                && Objects.equals(eventType, other.eventType) 
-                && Objects.equals(id, other.id) 
-                && Objects.equals(messageId, other.messageId) 
-                && Objects.equals(parentProcessInstanceId, other.parentProcessInstanceId) 
-                && Objects.equals(processDefinitionId, other.processDefinitionId) 
-                && Objects.equals(processDefinitionKey, other.processDefinitionKey) 
-                && Objects.equals(processInstanceId, other.processInstanceId) 
-                && sequenceNumber == other.sequenceNumber 
-                && Objects.equals(serviceFullName, other.serviceFullName) 
-                && Objects.equals(serviceName, other.serviceName) 
-                && Objects.equals(serviceType, other.serviceType) 
-                && Objects.equals(serviceVersion, other.serviceVersion) 
+        return Objects.equals(appName, other.appName)
+                && Objects.equals(appVersion, other.appVersion)
+                && Objects.equals(businessKey, other.businessKey)
+                && Objects.equals(entityId, other.entityId)
+                && Objects.equals(eventId, other.eventId)
+                && Objects.equals(eventType, other.eventType)
+                && Objects.equals(id, other.id)
+                && Objects.equals(messageId, other.messageId)
+                && Objects.equals(parentProcessInstanceId, other.parentProcessInstanceId)
+                && Objects.equals(processDefinitionId, other.processDefinitionId)
+                && Objects.equals(processDefinitionKey, other.processDefinitionKey)
+                && Objects.equals(processInstanceId, other.processInstanceId)
+                && sequenceNumber == other.sequenceNumber
+                && Objects.equals(serviceFullName, other.serviceFullName)
+                && Objects.equals(serviceName, other.serviceName)
+                && Objects.equals(serviceType, other.serviceType)
+                && Objects.equals(serviceVersion, other.serviceVersion)
                 && Objects.equals(timestamp, other.timestamp);
     }
 

--- a/activiti-cloud-starter-audit/src/main/resources/config/audit/liquibase/changelog/initial.h2.schema.sql
+++ b/activiti-cloud-starter-audit/src/main/resources/config/audit/liquibase/changelog/initial.h2.schema.sql
@@ -1,4 +1,4 @@
-create sequence hibernate_sequence start with 1 increment by 1;
+create sequence audit_sequence start with 1 increment by 1;
 create table audit_event
 (
     type                       varchar(31) not null,

--- a/activiti-cloud-starter-audit/src/main/resources/config/audit/liquibase/changelog/initial.mysql.schema.sql
+++ b/activiti-cloud-starter-audit/src/main/resources/config/audit/liquibase/changelog/initial.mysql.schema.sql
@@ -40,9 +40,9 @@ create table audit_event
     variable_type              varchar(255),
     primary key (id)
 ) engine=MyISAM;
-create table hibernate_sequence
+create table audit_sequence
 (
     next_val bigint
 ) engine=MyISAM;
-insert into hibernate_sequence
+insert into audit_sequence
 values (1);

--- a/activiti-cloud-starter-audit/src/main/resources/config/audit/liquibase/changelog/initial.postgres.schema.sql
+++ b/activiti-cloud-starter-audit/src/main/resources/config/audit/liquibase/changelog/initial.postgres.schema.sql
@@ -1,4 +1,4 @@
-create sequence hibernate_sequence start 1 increment 1;
+create sequence audit_sequence start 1 increment 1;
 create table audit_event
 (
     type                       varchar(31) not null,


### PR DESCRIPTION
Audit tries to create hibernate_sequence even if it is present
Could be present because of a previous deploy created it before OR because of another module created it

Solution

assign a different name to the sequence: audit-sequence