### PR TITLE
refactor(build): removed component scans from configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,6 @@ after_failure:
   - cat **/target/surefire-reports/*.xml | grep -B 1 -A 10 "<error"
   - cat **/target/failsafe-reports/*.xml | grep -B 1 -A 10 "<error"
 
-env:
-  global:
-  - DOCKER_HOST=tcp://127.0.0.1:2375
+# env:
+#   global:
+#   - DOCKER_HOST=tcp://127.0.0.1:2375

--- a/activiti-cloud-services-audit-api/pom.xml
+++ b/activiti-cloud-services-audit-api/pom.xml
@@ -54,11 +54,8 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -67,15 +64,6 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-stream</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-hateoas</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -113,7 +101,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-test-autoconfigure</artifactId>
-      <scope>test</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/activiti-cloud-services-audit-jpa/pom.xml
+++ b/activiti-cloud-services-audit-jpa/pom.xml
@@ -109,40 +109,24 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-messaging</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.persistence</groupId>
+      <artifactId>javax.persistence-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-jpa</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-stream</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-hateoas</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-jpa</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-rest</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -176,6 +160,26 @@
     <dependency>
       <groupId>org.activiti.api</groupId>
       <artifactId>activiti-api-runtime-shared</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-rest</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/controllers/config/AuditJPAControllersAutoConfiguration.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/controllers/config/AuditJPAControllersAutoConfiguration.java
@@ -1,0 +1,17 @@
+package org.activiti.cloud.services.audit.jpa.controllers.config;
+
+import org.activiti.cloud.services.audit.jpa.controllers.AuditEventsAdminControllerImpl;
+import org.activiti.cloud.services.audit.jpa.controllers.AuditEventsControllerImpl;
+import org.activiti.cloud.services.audit.jpa.controllers.AuditEventsDeleteController;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({
+    AuditEventsAdminControllerImpl.class,
+    AuditEventsControllerImpl.class,
+    AuditEventsDeleteController.class
+})
+public class AuditJPAControllersAutoConfiguration {
+
+}

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/repository/config/AuditJPARepositoryAutoConfiguration.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/repository/config/AuditJPARepositoryAutoConfiguration.java
@@ -1,0 +1,14 @@
+package org.activiti.cloud.services.audit.jpa.repository.config;
+
+import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
+import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EnableJpaRepositories(basePackageClasses = EventsRepository.class)
+@EntityScan(basePackageClasses = AuditEventEntity.class)
+public class AuditJPARepositoryAutoConfiguration {
+
+}

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/security/SecurityPoliciesApplicationServiceImpl.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/security/SecurityPoliciesApplicationServiceImpl.java
@@ -1,8 +1,5 @@
 package org.activiti.cloud.services.audit.jpa.security;
 
-import java.util.Map;
-import java.util.Set;
-
 import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
@@ -11,12 +8,13 @@ import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager
 import org.activiti.core.common.spring.security.policies.SecurityPolicyAccess;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Applies security policies (defined into the application.properties file) to event data
  */
-@Component
 public class SecurityPoliciesApplicationServiceImpl extends BaseSecurityPoliciesManagerImpl implements SecurityPoliciesManager {
 
     public SecurityPoliciesApplicationServiceImpl(UserGroupManager userGroupManager,

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/security/config/AuditJPASecurityAutoConfiguration.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/security/config/AuditJPASecurityAutoConfiguration.java
@@ -1,0 +1,24 @@
+package org.activiti.cloud.services.audit.jpa.security.config;
+
+import org.activiti.api.runtime.shared.identity.UserGroupManager;
+import org.activiti.api.runtime.shared.security.SecurityManager;
+import org.activiti.cloud.services.audit.jpa.security.SecurityPoliciesApplicationServiceImpl;
+import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AuditJPASecurityAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SecurityPoliciesApplicationServiceImpl securityPoliciesApplicationService(UserGroupManager userGroupManager,
+                                                                                     SecurityManager securityManager,
+                                                                                     SecurityPoliciesProperties securityPoliciesProperties) {
+        return new SecurityPoliciesApplicationServiceImpl(userGroupManager, 
+                                                          securityManager, 
+                                                          securityPoliciesProperties);
+    }
+    
+}

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/streams/AuditConsumerChannelHandlerImpl.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/streams/AuditConsumerChannelHandlerImpl.java
@@ -26,18 +26,14 @@ import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.handler.annotation.Headers;
-import org.springframework.stereotype.Component;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-@Component
-@EnableBinding(AuditConsumerChannels.class)
+@SuppressWarnings("rawtypes")
 public class AuditConsumerChannelHandlerImpl implements AuditConsumerChannelHandler {
 
     private static Logger LOGGER = LoggerFactory.getLogger(AuditConsumerChannelHandlerImpl.class);
@@ -46,13 +42,13 @@ public class AuditConsumerChannelHandlerImpl implements AuditConsumerChannelHand
 
     private final APIEventToEntityConverters eventConverters;
 
-    @Autowired
     public AuditConsumerChannelHandlerImpl(EventsRepository eventsRepository,
                                            APIEventToEntityConverters eventConverters) {
         this.eventsRepository = eventsRepository;
         this.eventConverters = eventConverters;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     @StreamListener(AuditConsumerChannels.AUDIT_CONSUMER)
     public void receiveCloudRuntimeEvent(@Headers Map<String, Object> headers, CloudRuntimeEvent<?, ?>... events) {

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/streams/config/AuditJPAStreamsAutoConfiguration.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/streams/config/AuditJPAStreamsAutoConfiguration.java
@@ -1,0 +1,25 @@
+package org.activiti.cloud.services.audit.jpa.streams.config;
+
+import org.activiti.cloud.services.audit.api.converters.APIEventToEntityConverters;
+import org.activiti.cloud.services.audit.api.streams.AuditConsumerChannelHandler;
+import org.activiti.cloud.services.audit.api.streams.AuditConsumerChannels;
+import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
+import org.activiti.cloud.services.audit.jpa.streams.AuditConsumerChannelHandlerImpl;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableBinding(AuditConsumerChannels.class)
+public class AuditJPAStreamsAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AuditConsumerChannelHandler auditConsumerChannelHandler(EventsRepository eventsRepository,
+                                                                   APIEventToEntityConverters eventConverters) {
+        return new AuditConsumerChannelHandlerImpl(eventsRepository,
+                                                   eventConverters);
+    }
+
+}

--- a/activiti-cloud-services-audit-jpa/src/main/resources/META-INF/spring.factories
+++ b/activiti-cloud-services-audit-jpa/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,6 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-    org.activiti.cloud.services.audit.jpa.conf.AuditJPAAutoConfiguration
+    org.activiti.cloud.services.audit.jpa.conf.AuditJPAAutoConfiguration,\
+    org.activiti.cloud.services.audit.jpa.controllers.config.AuditJPAControllersAutoConfiguration,\
+    org.activiti.cloud.services.audit.jpa.repository.config.AuditJPARepositoryAutoConfiguration,\
+    org.activiti.cloud.services.audit.jpa.security.config.AuditJPASecurityAutoConfiguration,\
+	org.activiti.cloud.services.audit.jpa.streams.config.AuditJPAStreamsAutoConfiguration

--- a/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/Application.java
+++ b/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/Application.java
@@ -21,8 +21,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
-@ComponentScan(basePackages = {"org.activiti.cloud.services","org.activiti.cloud.alfresco","org.activiti.core.common.spring.identity",
-        "org.activiti.core.common.spring.security"})
 public class Application {
 
     public static void main(String[] args) {

--- a/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/controller/AuditEventDeleteControllerIT.java
+++ b/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/controller/AuditEventDeleteControllerIT.java
@@ -1,10 +1,22 @@
 package org.activiti.cloud.services.audit.jpa.controller;
 
+import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.resourcesResponseFields;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.activiti.api.process.model.events.ProcessRuntimeEvent;
 import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
 import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.activiti.api.runtime.shared.security.SecurityManager;
+import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
+import org.activiti.cloud.services.audit.api.config.AuditAPIAutoConfiguration;
 import org.activiti.cloud.services.audit.api.resources.EventsRelProvider;
+import org.activiti.cloud.services.audit.jpa.conf.AuditJPAAutoConfiguration;
 import org.activiti.cloud.services.audit.jpa.controllers.AuditEventsDeleteController;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.ProcessStartedAuditEventEntity;
@@ -17,6 +29,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
@@ -26,21 +39,17 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.resourcesResponseFields;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 @TestPropertySource(properties="activiti.rest.enable-deletion=true")
 @RunWith(SpringRunner.class)
 @WebMvcTest(AuditEventsDeleteController.class)
 @EnableSpringDataWebSupport
 @AutoConfigureMockMvc(secure = false)
 @AutoConfigureRestDocs(outputDir = "target/snippets")
+@Import({
+    AuditAPIAutoConfiguration.class,
+    AuditJPAAutoConfiguration.class,
+    AlfrescoWebAutoConfiguration.class
+})
 public class AuditEventDeleteControllerIT {
 
     private static final String DOCUMENTATION_ALFRESCO_IDENTIFIER = "events-alfresco";

--- a/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/controller/AuditEventsControllerImplIT.java
+++ b/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/controller/AuditEventsControllerImplIT.java
@@ -49,6 +49,9 @@ import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
 import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.argument.resolver.AlfrescoPageRequest;
+import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
+import org.activiti.cloud.services.audit.api.config.AuditAPIAutoConfiguration;
+import org.activiti.cloud.services.audit.jpa.conf.AuditJPAAutoConfiguration;
 import org.activiti.cloud.services.audit.jpa.controllers.AuditEventsControllerImpl;
 import org.activiti.cloud.services.audit.jpa.events.ActivityStartedAuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
@@ -60,6 +63,8 @@ import org.activiti.cloud.services.audit.jpa.events.ProcessStartedAuditEventEnti
 import org.activiti.cloud.services.audit.jpa.events.SignalReceivedAuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.TimerFiredAuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
+import org.activiti.cloud.services.audit.jpa.security.config.AuditJPASecurityAutoConfiguration;
+import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -68,6 +73,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -86,6 +92,12 @@ import java.util.Optional;
 @EnableSpringDataWebSupport
 @AutoConfigureMockMvc(secure = false)
 @AutoConfigureRestDocs(outputDir = "target/snippets")
+@Import({
+    AuditAPIAutoConfiguration.class,
+    AuditJPAAutoConfiguration.class,
+    AuditJPASecurityAutoConfiguration.class,
+    AlfrescoWebAutoConfiguration.class
+})
 public class AuditEventsControllerImplIT {
 
     private static final String DOCUMENTATION_IDENTIFIER = "events";
@@ -100,6 +112,9 @@ public class AuditEventsControllerImplIT {
     @MockBean
     private SecurityManager securityManager;
 
+    @MockBean
+    private SecurityPoliciesProperties securityPoliciesProperties;
+    
     @MockBean
     private UserGroupManager userGroupManager;
 

--- a/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/controller/EventsEngineEventsAdminControllerIT.java
+++ b/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/controller/EventsEngineEventsAdminControllerIT.java
@@ -16,35 +16,6 @@
 
 package org.activiti.cloud.services.audit.jpa.controller;
 
-import org.activiti.api.process.model.events.ProcessRuntimeEvent;
-import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
-import org.activiti.api.runtime.shared.identity.UserGroupManager;
-import org.activiti.api.runtime.shared.security.SecurityManager;
-import org.activiti.cloud.alfresco.argument.resolver.AlfrescoPageRequest;
-import org.activiti.cloud.services.audit.jpa.controllers.AuditEventsAdminControllerImpl;
-import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
-import org.activiti.cloud.services.audit.jpa.events.ProcessStartedAuditEventEntity;
-import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.web.config.EnableSpringDataWebSupport;
-import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pageRequestParameters;
 import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pagedResourcesResponseFields;
@@ -59,11 +30,49 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.activiti.api.process.model.events.ProcessRuntimeEvent;
+import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
+import org.activiti.api.runtime.shared.identity.UserGroupManager;
+import org.activiti.api.runtime.shared.security.SecurityManager;
+import org.activiti.cloud.alfresco.argument.resolver.AlfrescoPageRequest;
+import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
+import org.activiti.cloud.services.audit.api.config.AuditAPIAutoConfiguration;
+import org.activiti.cloud.services.audit.jpa.conf.AuditJPAAutoConfiguration;
+import org.activiti.cloud.services.audit.jpa.controllers.AuditEventsAdminControllerImpl;
+import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
+import org.activiti.cloud.services.audit.jpa.events.ProcessStartedAuditEventEntity;
+import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
 @RunWith(SpringRunner.class)
 @WebMvcTest(AuditEventsAdminControllerImpl.class)
 @EnableSpringDataWebSupport
 @AutoConfigureMockMvc(secure = false)
 @AutoConfigureRestDocs(outputDir = "target/snippets")
+@Import({
+    AuditAPIAutoConfiguration.class,
+    AuditJPAAutoConfiguration.class,
+    AlfrescoWebAutoConfiguration.class
+})
 public class EventsEngineEventsAdminControllerIT {
 
     private static final String DOCUMENTATION_IDENTIFIER = "events-admin";

--- a/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/security/RestrictEventQueryIT.java
+++ b/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/security/RestrictEventQueryIT.java
@@ -1,37 +1,30 @@
 package org.activiti.cloud.services.audit.jpa.security;
 
-import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
-import org.activiti.cloud.services.audit.jpa.events.ProcessStartedAuditEventEntity;
-import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.activiti.api.runtime.shared.security.SecurityManager;
+import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
+import org.activiti.cloud.services.audit.jpa.events.ProcessStartedAuditEventEntity;
+import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
 import org.activiti.core.common.spring.security.policies.SecurityPolicyAccess;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.Collections;
 import java.util.Iterator;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
-
 @RunWith(SpringJUnit4ClassRunner.class)
 @TestPropertySource("classpath:test-application.properties")
 @SpringBootTest
-@EnableConfigurationProperties
-@EnableJpaRepositories(basePackages = "org.activiti")
-@EntityScan("org.activiti")
 @EnableAutoConfiguration
 public class RestrictEventQueryIT {
 

--- a/activiti-cloud-starter-audit/pom.xml
+++ b/activiti-cloud-starter-audit/pom.xml
@@ -45,6 +45,18 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>    
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-hateoas</artifactId>
     </dependency>
     <dependency>

--- a/activiti-cloud-starter-audit/src/main/java/org/activiti/cloud/starter/audit/configuration/ActivitiAuditAutoConfiguration.java
+++ b/activiti-cloud-starter-audit/src/main/java/org/activiti/cloud/starter/audit/configuration/ActivitiAuditAutoConfiguration.java
@@ -1,15 +1,9 @@
 package org.activiti.cloud.starter.audit.configuration;
 
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @Configuration
-@ComponentScan({"org.activiti.cloud.services.audit",
-        "org.activiti.cloud.alfresco",
-        "org.activiti.core.common.spring.security.policies",
-        "org.activiti.cloud.services.common.security",
-        "org.activiti.cloud.services.identity"})
 @Import(SwaggerConfig.class)
 public class ActivitiAuditAutoConfiguration {
 

--- a/activiti-cloud-starter-audit/src/main/java/org/activiti/cloud/starter/audit/configuration/EnableActivitiAudit.java
+++ b/activiti-cloud-starter-audit/src/main/java/org/activiti/cloud/starter/audit/configuration/EnableActivitiAudit.java
@@ -1,21 +1,17 @@
 package org.activiti.cloud.starter.audit.configuration;
 
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-@EnableJpaRepositories("org.activiti.cloud.services.audit.jpa")
-@EntityScan(basePackages = {"org.activiti.cloud.services.audit.jpa.events","org.activiti.cloud.services.audit.jpa.events.model"})
 @Inherited
 @EnableDiscoveryClient
 @EnableAutoConfiguration

--- a/activiti-cloud-starter-audit/src/main/java/org/activiti/cloud/starter/audit/configuration/SwaggerConfig.java
+++ b/activiti-cloud-starter-audit/src/main/java/org/activiti/cloud/starter/audit/configuration/SwaggerConfig.java
@@ -16,18 +16,20 @@
 
 package org.activiti.cloud.starter.audit.configuration;
 
-import java.util.function.Predicate;
-
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.RequestHandler;
 import springfox.documentation.builders.RequestHandlerSelectors;
 
+import java.util.function.Predicate;
+
 @Configuration
 public class SwaggerConfig {
 
     @Bean
-    public Predicate<RequestHandler> apiSelector() {
+    @ConditionalOnMissingBean(name = "auditApiSelector")
+    public Predicate<RequestHandler> auditApiSelector() {
         return RequestHandlerSelectors.basePackage("org.activiti.cloud.services.audit")::apply;
     }
 

--- a/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/Application.java
+++ b/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/Application.java
@@ -19,15 +19,10 @@ package org.activiti.cloud.starter.audit.tests.it;
 import org.activiti.cloud.starter.audit.configuration.EnableActivitiAudit;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
 @EnableActivitiAudit
-@ComponentScan({"org.activiti.cloud.starters.test",
-        "org.activiti.cloud.starter.audit.tests.it",
-        "org.activiti.cloud.services.test.identity.keycloak.interceptor"})
 public class Application {
-
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class,

--- a/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
+++ b/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
@@ -20,14 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.process.model.events.BPMNActivityEvent;
 import org.activiti.api.process.model.events.BPMNErrorReceivedEvent;
@@ -82,16 +74,26 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext
 @TestPropertySource("classpath:application.properties")
+@Import(EventsRestTemplate.class)
 public class AuditServiceIT {
 
     @Autowired

--- a/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/EventsRestTemplate.java
+++ b/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/EventsRestTemplate.java
@@ -16,32 +16,23 @@
 
 package org.activiti.cloud.starter.audit.tests.it;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import static org.activiti.test.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.services.test.identity.keycloak.interceptor.KeycloakTokenProducer;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestComponent;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.context.annotation.Bean;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.PagedResources;
-import org.springframework.hateoas.hal.Jackson2HalModule;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.stereotype.Component;
 
-import static org.activiti.test.Assertions.assertThat;
+import java.util.Map;
 
-@Component
+@TestComponent
 public class EventsRestTemplate {
 
     private static final String RELATIVE_EVENTS_ENDPOINT = "/v1/events";
@@ -53,24 +44,6 @@ public class EventsRestTemplate {
     public EventsRestTemplate(ObjectMapper mapper, KeycloakTokenProducer keycloakTokenProducer) {
         this.mapper = mapper;
         this.keycloakTokenProducer = keycloakTokenProducer;
-    }
-
-    @Bean
-    public RestTemplateBuilder restTemplateBuilder  (List<Module> modules) {
-
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
-                         false);
-        mapper.registerModule(new Jackson2HalModule());
-        for (Module module : modules) {
-            mapper.registerModule(module);
-        }
-
-        MappingJackson2HttpMessageConverter jackson2HttpMessageConverter = new MappingJackson2HttpMessageConverter();
-        jackson2HttpMessageConverter.setSupportedMediaTypes(Collections.singletonList(MediaTypes.HAL_JSON));
-        jackson2HttpMessageConverter.setObjectMapper(mapper);
-
-        return new RestTemplateBuilder().additionalMessageConverters(
-                jackson2HttpMessageConverter);
     }
 
     @Autowired

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
   </repositories>
   <properties>
     <activiti-cloud-build.version>7.1.10</activiti-cloud-build.version>
-    <activiti-cloud-service-common.version>7.1.67</activiti-cloud-service-common.version>
+    <activiti-cloud-service-common.version>7.1.68</activiti-cloud-service-common.version>
     <activiti-cloud-audit-service.version>${project.version}</activiti-cloud-audit-service.version>
     <json-unit.version>1.24.0</json-unit.version>
     <testcontainers.version>1.12.0</testcontainers.version>


### PR DESCRIPTION
This PR fixes Spring Boot bean override problems by removing component scans from configuration classes and adds missing @ConditionalOnMissingBean annotation on beans created in Activiti Runtime Spring Boot Auto-configurations

Depends on https://github.com/Activiti/activiti-cloud-service-common/pull/207

Fixes https://github.com/Activiti/Activiti/issues/1399