### PR TITLE
fix(AAE-201): Refactored Security Policy Service to use extended SecurityManager groups Apis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ hs_err_pid*
 .updatebot-repos/**
 
 *.versionsBackup
+.sts4-cache

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/security/SecurityPoliciesApplicationServiceImpl.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/security/SecurityPoliciesApplicationServiceImpl.java
@@ -1,6 +1,5 @@
 package org.activiti.cloud.services.audit.jpa.security;
 
-import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
 import org.activiti.core.common.spring.security.policies.BaseSecurityPoliciesManagerImpl;
@@ -17,11 +16,9 @@ import java.util.Set;
  */
 public class SecurityPoliciesApplicationServiceImpl extends BaseSecurityPoliciesManagerImpl implements SecurityPoliciesManager {
 
-    public SecurityPoliciesApplicationServiceImpl(UserGroupManager userGroupManager,
-                                                  SecurityManager securityManager,
+    public SecurityPoliciesApplicationServiceImpl(SecurityManager securityManager,
                                                   SecurityPoliciesProperties securityPoliciesProperties) {
-        super(userGroupManager,
-              securityManager,
+        super(securityManager,
               securityPoliciesProperties);
     }
 

--- a/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/security/config/AuditJPASecurityAutoConfiguration.java
+++ b/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/security/config/AuditJPASecurityAutoConfiguration.java
@@ -1,6 +1,5 @@
 package org.activiti.cloud.services.audit.jpa.security.config;
 
-import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.services.audit.jpa.security.SecurityPoliciesApplicationServiceImpl;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
@@ -13,11 +12,9 @@ public class AuditJPASecurityAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public SecurityPoliciesApplicationServiceImpl securityPoliciesApplicationService(UserGroupManager userGroupManager,
-                                                                                     SecurityManager securityManager,
+    public SecurityPoliciesApplicationServiceImpl securityPoliciesApplicationService(SecurityManager securityManager,
                                                                                      SecurityPoliciesProperties securityPoliciesProperties) {
-        return new SecurityPoliciesApplicationServiceImpl(userGroupManager, 
-                                                          securityManager, 
+        return new SecurityPoliciesApplicationServiceImpl(securityManager, 
                                                           securityPoliciesProperties);
     }
     

--- a/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/security/RestrictEventQueryIT.java
+++ b/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/security/RestrictEventQueryIT.java
@@ -93,7 +93,7 @@ public class RestrictEventQueryIT {
         eventsRepository.save(eventEntity);
 
         when(securityManager.getAuthenticatedUserId()).thenReturn("bobinhr");
-        when(userGroupManager.getUserGroups("bobinhr")).thenReturn(Collections.singletonList("hrgroup"));
+        when(securityManager.getAuthenticatedUserGroups()).thenReturn(Collections.singletonList("hrgroup"));
 
         Specification<AuditEventEntity> spec = securityPoliciesApplicationService.createSpecWithSecurity(null,
                 SecurityPolicyAccess.READ);

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
   </repositories>
   <properties>
     <activiti-cloud-build.version>7.1.11</activiti-cloud-build.version>
-    <activiti-cloud-service-common.version>7.1.75</activiti-cloud-service-common.version>
+    <activiti-cloud-service-common.version>7.1.76</activiti-cloud-service-common.version>
     <activiti-cloud-audit-service.version>${project.version}</activiti-cloud-audit-service.version>
     <json-unit.version>1.24.0</json-unit.version>
     <testcontainers.version>1.12.0</testcontainers.version>


### PR DESCRIPTION
This PR refactors SecurityPolicyManagementService to use extended SecurityManager groups Apis to apply restrictions.

Depends on https://github.com/Activiti/activiti-cloud-service-common/pull/174

Part of https://github.com/Activiti/Activiti/issues/2765