### PR TITLE
fix(AAE-731): Added ACT_AUDIT_CONSUMER_* metadata configuration property placeholders

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
       ORG               = 'activiti'
       APP_NAME          = 'activiti-cloud-audit-service'
       CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+      RELEASE_BRANCH = "develop"
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -13,7 +14,7 @@ pipeline {
           branch 'PR-*'
         }
         environment {
-          PREVIEW_VERSION = "0.0.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
+          PREVIEW_VERSION = maven_project_version().replaceAll("SNAPSHOT","$BRANCH_NAME-$BUILD_NUMBER-SNAPSHOT")
           PREVIEW_NAMESPACE = "$APP_NAME-$BRANCH_NAME".toLowerCase()
           HELM_RELEASE = "$PREVIEW_NAMESPACE".toLowerCase()
         }
@@ -21,12 +22,16 @@ pipeline {
           container('maven') {
             sh "mvn versions:set -DnewVersion=$PREVIEW_VERSION"
             sh "mvn install"
+            sh "mvn deploy -DskipTests"
           }
         }
       }
       stage('Build Release') {
         when {
-          branch 'develop'
+          branch "$RELEASE_BRANCH"
+        }
+        environment {
+          VERSION = jx_release_version()      
         }
         steps {
           container('maven') {
@@ -36,29 +41,27 @@ pipeline {
 
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(jx-release-version) > VERSION"
-            sh "mvn versions:set -DnewVersion=\$(cat VERSION)"
+            sh "echo $VERSION > VERSION"
+            sh "mvn versions:set -DnewVersion=$VERSION"
 
             sh 'mvn clean verify'
 
             retry(5){
               sh "git add --all"
-              sh "git commit -m \"Release \$(cat VERSION)\" --allow-empty"
-              sh "git tag -fa v\$(cat VERSION) -m \"Release version \$(cat VERSION)\""
-              sh "git push origin v\$(cat VERSION)"
+              sh "git commit -m \"Release $VERSION\" --allow-empty"
+              sh "git tag -fa v$VERSION -m \"Release version $VERSION\""
+              sh "git push origin v$VERSION"
             }
-          }
-          container('maven') {
+            
             sh 'mvn clean deploy -DskipTests'
 
-            sh 'export VERSION=`cat VERSION`'
-            
             sh "jx step git credentials"
+            
             retry(2){
-              sh "updatebot push-version --kind maven org.activiti.cloud.audit:activiti-cloud-audit-dependencies \$(cat VERSION)"
+              sh "updatebot push-version --kind maven org.activiti.cloud.audit:activiti-cloud-audit-dependencies $VERSION"
               sh "rm -rf .updatebot-repos/"
               sh "sleep \$((RANDOM % 10))"
-              sh "updatebot push-version --kind maven org.activiti.cloud.audit:activiti-cloud-audit-dependencies \$(cat VERSION)"
+              sh "updatebot push-version --kind maven org.activiti.cloud.audit:activiti-cloud-audit-dependencies $VERSION"
             }
           }
         }
@@ -77,8 +80,7 @@ pipeline {
             // so we can retrieve the version in later steps
             sh "echo \$TAG_NAME > VERSION"
             sh "mvn versions:set -DnewVersion=\$(cat VERSION)"
-          }
-          container('maven') {
+            
             sh '''
               mvn clean deploy -P !alfresco -P central
               '''
@@ -111,4 +113,16 @@ pipeline {
             cleanWs()
         }
     }
-  }
+}
+
+def jx_release_version() {
+    container('maven') {
+        return sh( script: "echo \$(jx-release-version)", returnStdout: true).trim()
+    }
+}
+
+def maven_project_version() {
+    container('maven') {
+        return sh( script: "echo \$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout -f pom.xml)", returnStdout: true).trim()
+    }
+}  

--- a/activiti-cloud-starter-audit/src/main/resources/metadata.properties
+++ b/activiti-cloud-starter-audit/src/main/resources/metadata.properties
@@ -7,3 +7,8 @@ spring.liquibase.change-log=classpath:config/audit/liquibase/master.xml
 spring.liquibase.database-change-log-table=DATABASECHANGELOG_AUDIT
 spring.liquibase.database-change-log-lock-table=DATABASECHANGELOGLOCK_AUDIT
 
+spring.cloud.stream.bindings.auditConsumer.consumer.partitioned=${ACT_AUDIT_CONSUMER_PARTITIONED:false}
+spring.cloud.stream.bindings.auditConsumer.consumer.instance-count=${ACT_AUDIT_CONSUMER_INSTANCE_COUNT:1}
+spring.cloud.stream.bindings.auditConsumer.consumer.instance-index=${ACT_AUDIT_CONSUMER_INSTANCE_INDEX:0}
+spring.cloud.stream.bindings.auditConsumer.consumer.concurrency=${ACT_AUDIT_CONSUMER_CONCURRENCY:1}
+spring.cloud.stream.rabbit.bindings.auditConsumer.consumer.prefetch=${ACT_AUDIT_CONSUMER_PREFETCH:20}


### PR DESCRIPTION
This PR adds property placeholders into metadata.properties in order to be able to configure audit consumer Spring Cloud Stream properties via Helm chart.

```
spring.cloud.stream.bindings.auditConsumer.consumer.partitioned=${ACT_AUDIT_CONSUMER_PARTITIONED:false}
spring.cloud.stream.bindings.auditConsumer.consumer.instance-count=${ACT_AUDIT_CONSUMER_INSTANCE_COUNT:1}
spring.cloud.stream.bindings.auditConsumer.consumer.instance-index=${ACT_AUDIT_CONSUMER_INSTANCE_INDEX:0}
spring.cloud.stream.bindings.auditConsumer.consumer.concurrency=${ACT_AUDIT_CONSUMER_CONCURRENCY:1}
spring.cloud.stream.rabbit.bindings.auditConsumer.consumer.prefetch=${ACT_AUDIT_CONSUMER_PREFETCH:20}
```

Fixes AAE-731