### PR TITLE
fix: Extracted external dependencies to root pom dependency management

### DIFF
--- a/activiti-cloud-audit-dependencies/pom.xml
+++ b/activiti-cloud-audit-dependencies/pom.xml
@@ -14,13 +14,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.activiti.cloud.common</groupId>
-        <artifactId>activiti-cloud-service-common-dependencies</artifactId>
-        <version>${activiti-cloud-service-common.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>    
-      <dependency>
         <groupId>org.activiti.cloud.audit</groupId>
         <artifactId>activiti-cloud-services-audit-parent</artifactId>
         <version>${activiti-cloud-audit-service.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,13 @@
         <type>pom</type>
       </dependency>
       <dependency>
+        <groupId>org.activiti.cloud.common</groupId>
+        <artifactId>activiti-cloud-service-common-dependencies</artifactId>
+        <version>${activiti-cloud-service-common.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>    
+      <dependency>
         <groupId>net.javacrumbs.json-unit</groupId>
         <artifactId>json-unit-fluent</artifactId>
         <version>${json-unit.version}</version>


### PR DESCRIPTION
This PR fixes activiti-cloud-runtime-bundle-dependencies management BoM to extract external dependencies BoMs into root pom dependency management section

Part of https://github.com/Activiti/Activiti/issues/3099